### PR TITLE
bugfix: remove unintended margin for textarea element when label is empty

### DIFF
--- a/app/base.tsx
+++ b/app/base.tsx
@@ -216,9 +216,11 @@ function RenderedTreeNode({
       const { label, ...args } = props;
       return (
         <div className="gui-input gui-input-textarea">
-          <label>
-            <RenderedMarkdown body={label} />
-          </label>
+          { label &&
+            <label>
+              <RenderedMarkdown body={label} />
+            </label>
+          }
           <div>
             <textarea {...args} />
           </div>


### PR DESCRIPTION
This was causing extra margin for textarea elements, and alignment
issues, when the label was supposed to be an empty string.

This is how it looks now:
<img width="539" alt="image" src="https://github.com/dara-network/gooey-ui/assets/37668193/ba7613b0-dab5-4aac-9627-857d83a35081">

Connected ticket: https://app.asana.com/0/1203067047205953/1205594504378332/f