### PR TITLE
Add fontawesome kit to root.tsx

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -43,6 +43,7 @@ export default function App() {
         <meta name="viewport" content="width=device-width,initial-scale=1" />
         <Meta />
         <Links />
+        <script src="https://kit.fontawesome.com/8af9787bd5.js" crossorigin="anonymous"></script>
       </head>
       <body>
         <div


### PR DESCRIPTION
This commit adds fontawesome kit JS to the root template.

It is added directly to the root.tsx page rather than as components because fontawesome needs the script to be put into the <head> tag, whereas otherwise, it's only the styles that go into `<head>` and the scripts go at the bottom of `<body>`.