### PR TITLE
Allow only rendering date and add .no-margin CSS class to undo default styling

### DIFF
--- a/app/renderedHTML.tsx
+++ b/app/renderedHTML.tsx
@@ -54,10 +54,15 @@ function RenderLocalDt({
       "en-IN",
       renderLocalDtDateOptions,
     );
-    const localTimeString = date
-      .toLocaleTimeString("en-IN", renderLocalDtTimeOptions)
-      .toUpperCase();
-    setBody(localeDateString + yearToShow + ", " + localTimeString);
+    let result = localeDateString + yearToShow;
+    if (renderLocalDtTimeOptions) {
+      console.log(renderLocalDtTimeOptions);
+      const localTimeString = date
+        .toLocaleTimeString("en-IN", renderLocalDtTimeOptions)
+        .toUpperCase();
+      result += ", " + localTimeString;
+    }
+    setBody(result);
   }, [body, renderLocalDt, renderLocalDtDateOptions, renderLocalDtTimeOptions]);
 
   const parsedElements = parse(body2, reactParserOptions);

--- a/app/styles/custom.css
+++ b/app/styles/custom.css
@@ -4,6 +4,10 @@
 
 /* avenir-lt-w01_85-heavy1475544,avenir-lt-w05_85-heavy,sans-serif */
 
+.no-margin * {
+  margin: unset;
+}
+
 .streamlit-like-btn,
 .streamlit-like-btn:visited,
 .streamlit-like-btn:hover,


### PR DESCRIPTION
- local datetime: only show date (and not time) when time options is null
- Add .no-margin class to unset margin from all children
