### PR TITLE
Set py-0 for modal-footer

### DIFF
--- a/py/gooey_gui/components/modal.py
+++ b/py/gooey_gui/components/modal.py
@@ -159,5 +159,5 @@ def modal_scaffold(
             return (
                 gui.div(className="modal-header border-0"),
                 gui.div(className="modal-body"),
-                gui.div(className="modal-footer border-0 pb-0"),
+                gui.div(className="modal-footer border-0 py-0"),
             )


### PR DESCRIPTION
- fix padding and alignment for close button in alert dialog
- set no vertical padding for modal-footer by default (for empty footers)
