### PR TITLE
fix: remove z-index from header

### DIFF
--- a/app/styles/custom.css
+++ b/app/styles/custom.css
@@ -245,15 +245,10 @@ h6 {
 /* header */
 .header {
   background: #fff 0% 0% no-repeat padding-box;
-
-  z-index: 9;
   width: 100%;
   transition: all 0.2s ease-in-out;
 }
 
-/*.header:hover{
-    box-shadow:  0px 3px 6px #00000029;
-}*/
 .sticky-bar {
   background: #fff;
 }


### PR DESCRIPTION
This fix was added as we encountered a issue where, the workspace dropdown selector was not able to be at the top z-index and hence making the items inside it being un-clickable

https://app.asana.com/1/1199619908176999/project/1203067047205953/task/1213818665216645?focus=true